### PR TITLE
Scroll.toElement()

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,21 @@ You can manually scroll to any portion of a page and detect when done.
 var scroll = new Scroll({
     el: document.body
 });
-scroll.to(0, 500, function () {
-    //scrolling down 500 pixels has completed!
+scroll.to(0, 500).then(function () {
+   //scrolling down 500 pixels has completed!
+});
+
+```
+
+### Scroll to an element
+
+```javascript
+var myElement = document.body.getElementsByClassName('my-element')[0];
+var scroll = new Scroll({
+    el: document.body
+});
+scroll.toElement(myElement).then(function () {
+    // done scrolling to the element
 });
 
 ```

--- a/src/scroll.js
+++ b/src/scroll.js
@@ -58,6 +58,35 @@ Scroll.prototype = {
     },
 
     /**
+     * Scroll to an element.
+     * @param {HTMLElement} el - The element to scroll to.
+     * @param {Object} [options] - The scroll options
+     */
+    toElement: function (el, options) {
+        var container = this.options.el,
+            currentContainerScrollYPos = 0,
+            elementScrollYPos = el.offsetTop;
+
+        // if the container is the document body, we'll
+        // need a different set of coordinates for accuracy
+        if (container === document.body) {
+            // using pageYOffset for cross-browser compatibility
+            currentContainerScrollYPos = window.pageYOffset;
+            // must add containers scroll y position to ensure an absolute value that does not change
+            elementScrollYPos = el.getBoundingClientRect().top + currentContainerScrollYPos;
+        }
+        if (!el) {
+            console.warn('Scroll.toElement() must be passed an existing el');
+            return Promise.reject();
+        } else if (!container.contains(el)) {
+            console.warn('Scroll.toElement() Error: element you want to scroll to must live inside the scroll container');
+            return Promise.reject();
+        } else {
+            return this.to(0, elementScrollYPos, options);
+        }
+    },
+
+    /**
      * Does a bit of calculating and scrolls an element.
      * @param {HTMLElement} el - The element to be scrolled
      * @param {Number} from - The number of where to scroll from

--- a/tests/scroll-tests.js
+++ b/tests/scroll-tests.js
@@ -2,6 +2,7 @@
 var sinon = require('sinon');
 var assert = require('assert');
 var Scroll = require('../src/scroll');
+var Promise = require('promise');
 
 describe('Scroll', function () {
 
@@ -41,6 +42,92 @@ describe('Scroll', function () {
             document.body.removeChild(outerEl);
         });
     });
+
+    it('passing an absolutely positioned element toElement() should call .to() with the amount of distance the element is from the top of its container', function() {
+        var scrollToStub =  sinon.stub(Scroll.prototype, 'to').returns(Promise.resolve());
+        var outerEl = document.createElement('div');
+        var innerEl = document.createElement('div');
+        outerEl.appendChild(innerEl);
+        document.body.appendChild(outerEl);
+        // setup to be "scrollable"
+        outerEl.style.overflow = 'hidden';
+        outerEl.style.width = '200px'; // put some arbitrary width
+        outerEl.style.height = '150px';
+        outerEl.style.position = 'relative';
+        // inner element
+        innerEl.style.width = '100%';
+        innerEl.style.height = '600px';
+        innerEl.style.position = 'absolute';
+        innerEl.style.left = '0';
+        var innerElFromTop = 156;
+        innerEl.style.top = innerElFromTop + 'px';
+        // setup current scroll position
+        outerEl.scrollTop = 100;
+        var scroll = new Scroll({el: outerEl});
+        // test
+        return scroll.toElement(innerEl).then(function () {
+            assert.equal(scrollToStub.args[0][0], 0, 'to() was called with 0 as first parameter');
+            assert.equal(scrollToStub.args[0][1], innerElFromTop, 'to() was called with inner elements position (from top of outer element) as second parameter');
+            scrollToStub.restore();
+            document.body.removeChild(outerEl);
+        });
+    });
+
+    it('passing an absolutely positioned element toElement() when container is a document.body element should call .to() with the amount of distance the element is from the top of document.body el', function() {
+        var scrollToStub =  sinon.stub(Scroll.prototype, 'to').returns(Promise.resolve());
+        var docEl = document.body;
+        var innerEl = document.createElement('div');
+        docEl.appendChild(innerEl);
+        // inner element
+        innerEl.style.width = '100%';
+        innerEl.style.height = '600px';
+        innerEl.style.position = 'absolute';
+        innerEl.style.left = '0';
+        var innerElFromTop = 210;
+        innerEl.style.top = innerElFromTop + 'px';
+        // setup current scroll position
+        docEl.scrollTop = 100;
+        var scroll = new Scroll({el: docEl});
+        // test
+        return scroll.toElement(innerEl).then(function () {
+            assert.equal(scrollToStub.args[0][0], 0, 'to() was called with 0 as first parameter');
+            assert.equal(scrollToStub.args[0][1], innerElFromTop, 'to() was called with inner elements position (from top of document.body el) as second parameter');
+            scrollToStub.restore();
+            docEl.removeChild(innerEl);
+        });
+    });
+
+    it('passing an element to toElement() that is inside of a container that is inside the document.body element under an element with a designated height should call .to() with the amount of distance the element is from the top of document.body el', function() {
+        var scrollToStub =  sinon.stub(Scroll.prototype, 'to').returns(Promise.resolve());
+        var docEl = document.body;
+        var containerEl = document.createElement('div');
+        // remove any auto padding/margins for our test
+        containerEl.style.position = 'absolute';
+        containerEl.style.top = '0';
+        containerEl.style.left = '0';
+        docEl.appendChild(containerEl);
+        // padded inner el
+        var firstInnerElHeight = 73;
+        var firstInnerEl = document.createElement('div');
+        firstInnerEl.style.width = '100%';
+        firstInnerEl.style.height = firstInnerElHeight + 'px';
+        containerEl.appendChild(firstInnerEl);
+        // inner element
+        var innerEl = document.createElement('div');
+        innerEl.style.width = '100%';
+        innerEl.style.height = '200px';
+        containerEl.appendChild(innerEl);
+        // setup current scroll position
+        var scroll = new Scroll({el: docEl});
+        // test
+        return scroll.toElement(innerEl).then(function () {
+            assert.equal(scrollToStub.args[0][0], 0, 'to() was called with 0 as first parameter');
+            assert.equal(scrollToStub.args[0][1], firstInnerElHeight, 'to() was called with inner elements position (from top of document body el PLUS top padding) as second parameter');
+            scrollToStub.restore();
+            docEl.removeChild(containerEl);
+        });
+    });
+
 });
 
     


### PR DESCRIPTION
Adds a new Scroll.toElement() method that allows you to scroll to any element in the DOM.